### PR TITLE
chore: add Node.js CRC32 for comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # benchmark-aws-crt-crc32
 
-Benchmark AWS Crypto JS checksum implementation vs ones provided by AWS CRT
+Benchmark AWS Crypto JS checksum implementation vs ones provided by AWS CRT vs Node.js built-in.
 
 ## Pre-requisites
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,26 @@ Benchmark AWS Crypto JS checksum implementation vs ones provided by AWS CRT vs N
 $ yarn bench
 
 Benchmark for buffer of size 16 KB:
-awsCrc32 x 5,807 ops/sec ±1.30% (96 runs sampled)
-awsCrtCrc32 x 398,353 ops/sec ±1.37% (92 runs sampled)
-Fastest is awsCrtCrc32
+awsCrc32 x 5,878 ops/sec ±0.47% (98 runs sampled)
+awsCrtCrc32 x 396,066 ops/sec ±1.08% (93 runs sampled)
+nodeJsCrc32 x 562,327 ops/sec ±14.53% (83 runs sampled)
+Fastest is nodeJsCrc32
 
 Benchmark for buffer of size 64 KB:
-awsCrc32 x 1,149 ops/sec ±1.16% (78 runs sampled)
-awsCrtCrc32 x 120,999 ops/sec ±0.84% (98 runs sampled)
-Fastest is awsCrtCrc32
+awsCrc32 x 855 ops/sec ±1.76% (65 runs sampled)
+awsCrtCrc32 x 112,400 ops/sec ±1.94% (83 runs sampled)
+nodeJsCrc32 x 294,393 ops/sec ±7.50% (89 runs sampled)
+Fastest is nodeJsCrc32
 
 Benchmark for buffer of size 256 KB:
-awsCrc32 x 337 ops/sec ±0.90% (87 runs sampled)
-awsCrtCrc32 x 31,508 ops/sec ±0.82% (96 runs sampled)
-Fastest is awsCrtCrc32
+awsCrc32 x 278 ops/sec ±3.37% (76 runs sampled)
+awsCrtCrc32 x 25,769 ops/sec ±6.58% (80 runs sampled)
+nodeJsCrc32 x 92,877 ops/sec ±1.91% (92 runs sampled)
+Fastest is nodeJsCrc32
 
 Benchmark for buffer of size 1024 KB:
-awsCrc32 x 84.05 ops/sec ±0.53% (73 runs sampled)
-awsCrtCrc32 x 8,095 ops/sec ±0.22% (101 runs sampled)
-Fastest is awsCrtCrc32
+awsCrc32 x 58.60 ops/sec ±6.01% (62 runs sampled)
+awsCrtCrc32 x 7,273 ops/sec ±6.00% (89 runs sampled)
+nodeJsCrc32 x 22,771 ops/sec ±4.53% (92 runs sampled)
+Fastest is nodeJsCrc32
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "benchmark-aws-crt-crc32",
   "version": "1.0.0",
-  "description": "Benchmark AWS Crypto JS checksum implementation vs ones provided by AWS CRT",
+  "description": "Benchmark AWS Crypto JS checksum implementation vs ones provided by AWS CRT vs Node.js built-in",
   "main": "index.js",
   "scripts": {
     "bench": "node src/bench.js"

--- a/src/NodeJsCrc32.js
+++ b/src/NodeJsCrc32.js
@@ -1,0 +1,21 @@
+import { crc32 } from "node:zlib";
+
+export class NodeJsCrc32 {
+  update(toHash) {
+    this.previous = crc32(toHash, this.previous);
+  }
+
+  async digest() {
+    // numToUint8 from @aws-crypto/util
+    return new Uint8Array([
+      (this.previous & 0xff000000) >> 24,
+      (this.previous & 0x00ff0000) >> 16,
+      (this.previous & 0x0000ff00) >> 8,
+      this.previous & 0x000000ff,
+    ]);
+  }
+
+  reset() {
+    this.previous = undefined;
+  }
+}

--- a/src/bench.js
+++ b/src/bench.js
@@ -1,6 +1,7 @@
 import benchmark from "benchmark";
 import { AwsCrc32 } from "@aws-crypto/crc32";
 import { AwsCrtCrc32 } from "./AwsCrtCrc32.js";
+import { NodeJsCrc32 } from "./NodeJsCrc32.js";
 import { equal } from "assert";
 
 const generateBuffer = (size) => {
@@ -11,6 +12,7 @@ const generateBuffer = (size) => {
 
 const awsCrc32 = new AwsCrc32();
 const awsCrtCrc32 = new AwsCrtCrc32();
+const nodeJsCrc32 = new NodeJsCrc32();
 
 for (const bufferSizeInKB of [16, 64, 256, 1024]) {
   const suite = new benchmark.Suite();
@@ -18,10 +20,15 @@ for (const bufferSizeInKB of [16, 64, 256, 1024]) {
 
   awsCrc32.update(testBuffer);
   awsCrtCrc32.update(testBuffer);
+  nodeJsCrc32.update(testBuffer);
 
   equal(
     (await awsCrc32.digest()).toString(16),
     (await awsCrtCrc32.digest()).toString(16)
+  );
+  equal(
+    (await awsCrc32.digest()).toString(16),
+    (await nodeJsCrc32.digest()).toString(16)
   );
 
   console.log(`\nBenchmark for buffer of size ${bufferSizeInKB} KB:`);
@@ -34,7 +41,12 @@ for (const bufferSizeInKB of [16, 64, 256, 1024]) {
     .add("awsCrtCrc32", async () => {
       awsCrtCrc32.reset();
       awsCrtCrc32.update(testBuffer);
-      await awsCrtCrc32.digest(16);
+      await awsCrtCrc32.digest();
+    })
+    .add("nodeJsCrc32", async () => {
+      nodeJsCrc32.reset();
+      nodeJsCrc32.update(testBuffer);
+      await nodeJsCrc32.digest();
     })
     .on("cycle", (event) => {
       console.log(String(event.target));


### PR DESCRIPTION
```console
Benchmark for buffer of size 16 KB:
awsCrc32 x 5,878 ops/sec ±0.47% (98 runs sampled)
awsCrtCrc32 x 396,066 ops/sec ±1.08% (93 runs sampled)
nodeJsCrc32 x 562,327 ops/sec ±14.53% (83 runs sampled)
Fastest is nodeJsCrc32

Benchmark for buffer of size 64 KB:
awsCrc32 x 855 ops/sec ±1.76% (65 runs sampled)
awsCrtCrc32 x 112,400 ops/sec ±1.94% (83 runs sampled)
nodeJsCrc32 x 294,393 ops/sec ±7.50% (89 runs sampled)
Fastest is nodeJsCrc32

Benchmark for buffer of size 256 KB:
awsCrc32 x 278 ops/sec ±3.37% (76 runs sampled)
awsCrtCrc32 x 25,769 ops/sec ±6.58% (80 runs sampled)
nodeJsCrc32 x 92,877 ops/sec ±1.91% (92 runs sampled)
Fastest is nodeJsCrc32

Benchmark for buffer of size 1024 KB:
awsCrc32 x 58.60 ops/sec ±6.01% (62 runs sampled)
awsCrtCrc32 x 7,273 ops/sec ±6.00% (89 runs sampled)
nodeJsCrc32 x 22,771 ops/sec ±4.53% (92 runs sampled)
Fastest is nodeJsCrc32
```

The API was added in May 2024 in https://github.com/nodejs/node/pull/52692
It's available only in v22.2.0+ or v20.15.0+