### PR TITLE
chore: add version number in benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Benchmark AWS Crypto JS checksum implementation vs ones provided by AWS CRT vs N
 $ yarn bench
 
 Benchmark for buffer of size 16 KB:
-awsCrc32 x 5,878 ops/sec ±0.47% (98 runs sampled)
-awsCrtCrc32 x 396,066 ops/sec ±1.08% (93 runs sampled)
-nodeJsCrc32 x 562,327 ops/sec ±14.53% (83 runs sampled)
-Fastest is nodeJsCrc32
+@aws-crypto/crc32@5.2.0 x 5,699 ops/sec ±0.44% (92 runs sampled)
+aws-crt@1.22.0 x 389,210 ops/sec ±1.02% (89 runs sampled)
+node@20.17.0 x 567,192 ops/sec ±6.27% (81 runs sampled)
+Fastest is node@20.17.0
 
 Benchmark for buffer of size 64 KB:
-awsCrc32 x 855 ops/sec ±1.76% (65 runs sampled)
-awsCrtCrc32 x 112,400 ops/sec ±1.94% (83 runs sampled)
-nodeJsCrc32 x 294,393 ops/sec ±7.50% (89 runs sampled)
-Fastest is nodeJsCrc32
+@aws-crypto/crc32@5.2.0 x 780 ops/sec ±5.67% (91 runs sampled)
+aws-crt@1.22.0 x 112,347 ops/sec ±1.81% (90 runs sampled)
+node@20.17.0 x 282,874 ops/sec ±3.52% (80 runs sampled)
+Fastest is node@20.17.0
 
 Benchmark for buffer of size 256 KB:
-awsCrc32 x 278 ops/sec ±3.37% (76 runs sampled)
-awsCrtCrc32 x 25,769 ops/sec ±6.58% (80 runs sampled)
-nodeJsCrc32 x 92,877 ops/sec ±1.91% (92 runs sampled)
-Fastest is nodeJsCrc32
+@aws-crypto/crc32@5.2.0 x 267 ops/sec ±1.13% (86 runs sampled)
+aws-crt@1.22.0 x 30,813 ops/sec ±1.07% (91 runs sampled)
+node@20.17.0 x 91,469 ops/sec ±1.14% (94 runs sampled)
+Fastest is node@20.17.0
 
 Benchmark for buffer of size 1024 KB:
-awsCrc32 x 58.60 ops/sec ±6.01% (62 runs sampled)
-awsCrtCrc32 x 7,273 ops/sec ±6.00% (89 runs sampled)
-nodeJsCrc32 x 22,771 ops/sec ±4.53% (92 runs sampled)
-Fastest is nodeJsCrc32
+@aws-crypto/crc32@5.2.0 x 63.13 ops/sec ±0.69% (67 runs sampled)
+aws-crt@1.22.0 x 7,908 ops/sec ±0.46% (97 runs sampled)
+node@20.17.0 x 23,446 ops/sec ±2.88% (96 runs sampled)
+Fastest is node@20.17.0
 ```

--- a/src/bench.js
+++ b/src/bench.js
@@ -3,6 +3,7 @@ import { AwsCrc32 } from "@aws-crypto/crc32";
 import { AwsCrtCrc32 } from "./AwsCrtCrc32.js";
 import { NodeJsCrc32 } from "./NodeJsCrc32.js";
 import { equal } from "assert";
+import { readFileSync } from "fs";
 
 const generateBuffer = (size) => {
   const buf = Buffer.alloc(size);
@@ -10,40 +11,51 @@ const generateBuffer = (size) => {
   return buf;
 };
 
-const awsCrc32 = new AwsCrc32();
+const awsCryptoCrc32 = new AwsCrc32();
 const awsCrtCrc32 = new AwsCrtCrc32();
 const nodeJsCrc32 = new NodeJsCrc32();
+
+const getDependencyVersion = async (dependencyName) => {
+  const pkgJson = `${dependencyName}/package.json`;
+  const pkgJsonFilePath = await import.meta.resolve(pkgJson);
+  const pkgJsonPath = new URL(pkgJsonFilePath).pathname;
+  return JSON.parse(readFileSync(pkgJsonPath, "utf8")).version;
+};
 
 for (const bufferSizeInKB of [16, 64, 256, 1024]) {
   const suite = new benchmark.Suite();
   const testBuffer = generateBuffer(bufferSizeInKB * 1024);
 
-  awsCrc32.update(testBuffer);
+  awsCryptoCrc32.update(testBuffer);
   awsCrtCrc32.update(testBuffer);
   nodeJsCrc32.update(testBuffer);
 
   equal(
-    (await awsCrc32.digest()).toString(16),
+    (await awsCryptoCrc32.digest()).toString(16),
     (await awsCrtCrc32.digest()).toString(16)
   );
   equal(
-    (await awsCrc32.digest()).toString(16),
+    (await awsCryptoCrc32.digest()).toString(16),
     (await nodeJsCrc32.digest()).toString(16)
   );
 
+  const awsCryptoVersion = await getDependencyVersion("@aws-crypto/crc32");
+  const awsCrtVersion = await getDependencyVersion("aws-crt");
+  const nodeVersion = process.versions.node;
+
   console.log(`\nBenchmark for buffer of size ${bufferSizeInKB} KB:`);
   suite
-    .add("awsCrc32", async () => {
-      awsCrc32.reset();
-      awsCrc32.update(testBuffer);
-      await awsCrc32.digest();
+    .add(`@aws-crypto/crc32@${awsCryptoVersion}`, async () => {
+      awsCryptoCrc32.reset();
+      awsCryptoCrc32.update(testBuffer);
+      await awsCryptoCrc32.digest();
     })
-    .add("awsCrtCrc32", async () => {
+    .add(`aws-crt@${awsCrtVersion}`, async () => {
       awsCrtCrc32.reset();
       awsCrtCrc32.update(testBuffer);
       await awsCrtCrc32.digest();
     })
-    .add("nodeJsCrc32", async () => {
+    .add(`node@${nodeVersion}`, async () => {
       nodeJsCrc32.reset();
       nodeJsCrc32.update(testBuffer);
       await nodeJsCrc32.digest();


### PR DESCRIPTION
```console
$ yarn bench

Benchmark for buffer of size 16 KB:
@aws-crypto/crc32@5.2.0 x 5,699 ops/sec ±0.44% (92 runs sampled)
aws-crt@1.22.0 x 389,210 ops/sec ±1.02% (89 runs sampled)
node@20.17.0 x 567,192 ops/sec ±6.27% (81 runs sampled)
Fastest is node@20.17.0

Benchmark for buffer of size 64 KB:
@aws-crypto/crc32@5.2.0 x 780 ops/sec ±5.67% (91 runs sampled)
aws-crt@1.22.0 x 112,347 ops/sec ±1.81% (90 runs sampled)
node@20.17.0 x 282,874 ops/sec ±3.52% (80 runs sampled)
Fastest is node@20.17.0

Benchmark for buffer of size 256 KB:
@aws-crypto/crc32@5.2.0 x 267 ops/sec ±1.13% (86 runs sampled)
aws-crt@1.22.0 x 30,813 ops/sec ±1.07% (91 runs sampled)
node@20.17.0 x 91,469 ops/sec ±1.14% (94 runs sampled)
Fastest is node@20.17.0

Benchmark for buffer of size 1024 KB:
@aws-crypto/crc32@5.2.0 x 63.13 ops/sec ±0.69% (67 runs sampled)
aws-crt@1.22.0 x 7,908 ops/sec ±0.46% (97 runs sampled)
node@20.17.0 x 23,446 ops/sec ±2.88% (96 runs sampled)
Fastest is node@20.17.0
```